### PR TITLE
Change http:// to https:// in URLs that support HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # CommonMark web page
 
 This project contains:
-- http://commonmark.org homepage
-- Markdown syntax [reference sheet](http://commonmark.org/help/)
-- 10 minute Markdown essentials [tutorial](http://commonmark.org/help/tutorial/)
+- https://commonmark.org homepage
+- Markdown syntax [reference sheet](https://commonmark.org/help/)
+- 10 minute Markdown essentials [tutorial](https://commonmark.org/help/tutorial/)
 
 ## About CommonMark
 
-CommonMark is a strongly defined, highly compatible version of Markdown syntax. You can try it [here](http://try.commonmark.org/)
+CommonMark is a strongly defined, highly compatible version of Markdown syntax. You can try it [here](https://spec.commonmark.org/dingus/)

--- a/help/README.md
+++ b/help/README.md
@@ -1,23 +1,23 @@
-# **[commonmark.org/help](http://commonmark.org/help/)**
+# **[commonmark.org/help](https://commonmark.org/help/)**
 
-10 minute [interactive tutorial](http://commonmark.org/help/tutorial/) and 60 second [quick reference guide](http://commonmark.org/help/) for Markdown.
+10 minute [interactive tutorial](https://commonmark.org/help/tutorial/) and 60 second [quick reference guide](https://commonmark.org/help/) for Markdown.
 
 Everything is plain old HTML/CSS/Javascript with jQuery. Just download and open in a browser. Works on all screen sizes, from 30" to teeny-tiny iPhone 4 size.
 
 ##Projects used
 Big thanks to:
-- [Markdown Tutorial](http://markdowntutorial.com/)
+- [Markdown Tutorial](https://markdowntutorial.com/)
 - [Skeleton](http://getskeleton.com/)
-- [doT.js](http://olado.github.io/doT/index.html)
-- [Nanobar](http://nanobar.micronube.com/)
+- [doT.js](https://olado.github.io/doT/index.html)
+- [Nanobar](https://nanobar.jacoborus.codes/)
 - [Markdown-it](https://github.com/markdown-it/markdown-it)
 - [Sweet-Alert](https://github.com/t4t5/sweetalert)
 - [highlight.js](https://github.com/isagalaev/highlight.js)
-- [CodyHouse](http://codyhouse.co)
+- [CodyHouse](https://codyhouse.co)
 
 ##Compatibility
 All modern browsers, IE10+
 
 ##License:
 Open Source MIT.
-http://opensource.org/licenses/MIT
+https://opensource.org/licenses/MIT

--- a/help/css/confetti.css
+++ b/help/css/confetti.css
@@ -1,4 +1,4 @@
-/* from http://codepen.io/iprodev/pen/azpWBr */
+/* from https://codepen.io/iprodev/pen/azpWBr */
 
 #confetti {
   position: absolute;

--- a/help/css/menu.css
+++ b/help/css/menu.css
@@ -1,6 +1,6 @@
 /* -------------------------------- 
 
-Adapted from an article on CodyHouse (http://codyhouse.co/gem/vertical-fixed-navigation/)
+Adapted from an article on CodyHouse (https://codyhouse.co/gem/vertical-fixed-navigation/)
 
 -------------------------------- */
 

--- a/help/css/normalize-skeleton.css
+++ b/help/css/normalize-skeleton.css
@@ -432,7 +432,7 @@ th {
 * Copyright 2014, Dave Gamache
 * www.getskeleton.com
 * Free to use under the MIT license.
-* http://www.opensource.org/licenses/mit-license.php
+* https://www.opensource.org/licenses/mit-license.php
 * 12/29/2014
 */
 

--- a/help/css/points.css
+++ b/help/css/points.css
@@ -1,6 +1,6 @@
 /* -------------------------------- 
 
-Adapted from an article on CodyHouse (http://codyhouse.co/?p=258)
+Adapted from an article on CodyHouse (https://codyhouse.co/?p=258)
 
 -------------------------------- */
 

--- a/help/css/style.css
+++ b/help/css/style.css
@@ -1,6 +1,6 @@
 /*
 * Free to use under the MIT license.
-* http://www.opensource.org/licenses/mit-license.php
+* https://www.opensource.org/licenses/mit-license.php
 */
 
 
@@ -315,7 +315,7 @@ code, kbd, pre, samp, .editor, .html-pad, .preformatted {
 	display: none;
 }
 
-/* #Slide Menu (adapted from http://tympanus.net/codrops/2014/01/21/dot-navigation-styles/)
+/* #Slide Menu (adapted from https://tympanus.net/codrops/2014/01/21/dot-navigation-styles/)
 ================================================== */
 .dotstyle ul {
 	position: relative;

--- a/help/index.html
+++ b/help/index.html
@@ -81,7 +81,7 @@
                             &#8942;<br/>
                             [1]: http://b.org
                         </td>
-                        <td><a href="http://commonmark.org/">Link</a></td>
+                        <td><a href="https://commonmark.org/">Link</a></td>
                     </tr>
                     <tr>
                         <td class="preformatted">
@@ -207,12 +207,12 @@
                 
         <div class="twelve columns" style="margin-top: 2%">
             <p><b>Want to experiment with Markdown?</b></p>
-            <p>Try our <b><a href="tutorial/">10 minute interactive tutorial</a></b>, or <a href="http://try.commonmark.org/">play with the reference CommonMark implementation</a>.</p>
+            <p>Try our <b><a href="tutorial/">10 minute interactive tutorial</a></b>, or <a href="https://spec.commonmark.org/dingus/">play with the reference CommonMark implementation</a>.</p>
         </div>
 
         <div class="twelve columns">
             <p><b>Need more detail?</b></p>
-            <p>Refer to <a href="http://spec.commonmark.org">the official CommonMark spec</a>, or <a href="http://talk.commonmark.org">discuss CommonMark with us</a>.</p>
+            <p>Refer to <a href="https://spec.commonmark.org">the official CommonMark spec</a>, or <a href="https://talk.commonmark.org">discuss CommonMark with us</a>.</p>
         </div>
 
     </div>

--- a/help/js/confetti.js
+++ b/help/js/confetti.js
@@ -1,4 +1,4 @@
-// from http://codepen.io/iprodev/pen/azpWBr
+// from https://codepen.io/iprodev/pen/azpWBr
 
 var retina = window.devicePixelRatio,
 

--- a/help/js/exercises.js
+++ b/help/js/exercises.js
@@ -1,6 +1,6 @@
 /* 
 * Free to use under the MIT license.
-* http://www.opensource.org/licenses/mit-license.php
+* https://www.opensource.org/licenses/mit-license.php
 * 4/18/2015
 */
 
@@ -59,8 +59,8 @@ var exercises = {
 		correctMd: "1986\\. What a great season. Arguably the finest season in the history of the franchise."
 	},     
 	"6-1": {
-		answer: "<p>You can do anything at <a href=\"http://html5zombo.com\">http://html5zombo.com</a></p>",
-		correctMd: "You can do anything at <http://html5zombo.com>"
+		answer: "<p>You can do anything at <a href=\"https://html5zombo.com\">https://html5zombo.com</a></p>",
+		correctMd: "You can do anything at <https://html5zombo.com>"
 	}, 
 	"6-2": {
 		answer: "<p>The <a href=\"http://www.ur.ac.rw\">University of Rwanda</a> was formed in 2013 through the merger of Rwanda’s seven public institutions of higher education.</p>",
@@ -71,12 +71,12 @@ var exercises = {
 		correctMd: "[Hurricane][1] Erika was the strongest and longest-lasting tropical cyclone in the 1997 Atlantic [hurricane][1] season.\n\n[1]:https://goo.gl/YEEHP0"
 	}, 
 	"7-1": {
-		answer: "<p><img src=\"http://commonmark.org/help/images/favicon.png\" alt=\"\"></p>",
-		correctMd: "![](http://commonmark.org/help/images/favicon.png)"
+		answer: "<p><img src=\"https://commonmark.org/help/images/favicon.png\" alt=\"\"></p>",
+		correctMd: "![](https://commonmark.org/help/images/favicon.png)"
 	}, 
 	"7-2": {
-		answer: "<p><img src=\"http://commonmark.org/help/images/favicon.png\" alt=\"Logo\" title=\"Creative Commons licensed\"></p>",
-		correctMd: "![Logo][1]\n\n[1]: http://commonmark.org/help/images/favicon.png \"Creative Commons licensed\""
+		answer: "<p><img src=\"https://commonmark.org/help/images/favicon.png\" alt=\"Logo\" title=\"Creative Commons licensed\"></p>",
+		correctMd: "![Logo][1]\n\n[1]: https://commonmark.org/help/images/favicon.png \"Creative Commons licensed\""
 	}, 
 	"8-1": {
 		answer: "<p>When <code>x = 3</code>, that means <code>x + 2 = 5</code></p>",

--- a/help/js/menu.js
+++ b/help/js/menu.js
@@ -1,6 +1,6 @@
 /* 
 * Free to use under the MIT license.
-* http://www.opensource.org/licenses/mit-license.php
+* https://www.opensource.org/licenses/mit-license.php
 * 4/18/2015
 */
 

--- a/help/js/setup.js
+++ b/help/js/setup.js
@@ -1,6 +1,6 @@
 /* 
 * Free to use under the MIT license.
-* http://www.opensource.org/licenses/mit-license.php
+* https://www.opensource.org/licenses/mit-license.php
 * 4/18/2015
 */
 	

--- a/help/tutorial/07-links.html
+++ b/help/tutorial/07-links.html
@@ -127,7 +127,7 @@
                     </div>
                     <div class="row">
                         <div class="six columns">
-                            <textarea id="editor_6-1" class="editor">You can do anything at http://html5zombo.com</textarea>
+                            <textarea id="editor_6-1" class="editor">You can do anything at https://html5zombo.com</textarea>
                         </div>
                         <div class="six columns">
                             <div id="render_pad_6-1" class="render-pad"></div>

--- a/help/tutorial/08-images.html
+++ b/help/tutorial/08-images.html
@@ -138,7 +138,7 @@
                     </div>
                     <div class="row">
                         <div class="six columns">
-                            <textarea id="editor_7-1" class="editor">http://commonmark.org/help/images/favicon.png</textarea>
+                            <textarea id="editor_7-1" class="editor">https://commonmark.org/help/images/favicon.png</textarea>
                         </div>
                         <div class="six columns">
                             <div id="render_pad_7-1" class="render-pad"></div>
@@ -182,7 +182,7 @@
                         <div class="six columns">
                             <textarea id="editor_7-2" class="editor">![][1]
 
-[1]: http://commonmark.org/help/images/favicon.png</textarea>
+[1]: https://commonmark.org/help/images/favicon.png</textarea>
                         </div>
                         <div class="six columns">
                             <div id="render_pad_7-2" class="render-pad"></div>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                 </h2>
 
                 <p>
-                    John Gruber’s <a href="http://daringfireball.net/projects/markdown/syntax">canonical description of Markdown’s syntax</a> does not specify the syntax unambiguously.
+                    John Gruber’s <a href="https://daringfireball.net/projects/markdown/syntax">canonical description of Markdown’s syntax</a> does not specify the syntax unambiguously.
                 </p>
                 <p>
                     In the absence of a spec, early implementers consulted the original <code>Markdown.pl</code> code to resolve these ambiguities. But <code>Markdown.pl</code> was quite buggy, and gave manifestly bad results in many cases, so it was not a satisfactory replacement for a spec. <code>Markdown.pl</code> was last updated December 17<small>th</small>, 2004.
@@ -56,7 +56,7 @@
                     Because there is no unambiguous spec, implementations have diverged considerably over the last 10 years. As a result, users are often surprised to find that a document that renders one way on one system (say, a GitHub wiki) renders differently on another (say, converting to docbook using Pandoc). To make matters worse, because nothing in Markdown counts as a “syntax error,” the divergence often isn’t discovered right away.
                 </p>
                 <p>
-                    There’s no standard test suite for Markdown;  <a href="https://github.com/michelf/mdtest/">MDTest</a> is the closest thing we have. The only way to resolve Markdown ambiguities and inconsistencies is <a href="http://johnmacfarlane.net/babelmark2/">Babelmark</a>, which compares the output of 20+ implementations of Markdown against each other to see if a consensus emerges.
+                    There’s no standard test suite for Markdown;  <a href="https://github.com/michelf/mdtest/">MDTest</a> is the closest thing we have. The only way to resolve Markdown ambiguities and inconsistencies is <a href="https://johnmacfarlane.net/babelmark2/">Babelmark</a>, which compares the output of 20+ implementations of Markdown against each other to see if a consensus emerges.
                 </p>
                 <p>
                     We propose a <strong>standard, unambiguous syntax specification for Markdown</strong>, along with a <strong>suite of comprehensive tests</strong> to validate Markdown implementations against this specification. We believe this is necessary, even essential, for the future of Markdown.
@@ -86,16 +86,16 @@
                     <a id="how" class="anchor" href="#how"></a>How can I help?
                 </h2>
 
-                <p>Exercise our <a href="http://code.commonmark.org/">reference implementations</a>, or <a href="https://github.com/jgm/CommonMark/wiki/List-of-CommonMark-Implementations">find a community implementation</a> in your preferred environment or language. Provide <a href="http://talk.commonmark.org"></a>feedback!</p>
+                <p>Exercise our <a href="http://code.commonmark.org/">reference implementations</a>, or <a href="https://github.com/jgm/CommonMark/wiki/List-of-CommonMark-Implementations">find a community implementation</a> in your preferred environment or language. Provide <a href="https://talk.commonmark.org"></a>feedback!</p>
 
-                <p>If a CommonMark implementation does not already exist in your preferred environment or language, try <strong>implementing your own CommonMark parser</strong>. One of our major goals is to <a href="http://spec.commonmark.org/">strongly specify Markdown</a>, and to eliminate the many old inconsistencies and ambiguities that made using Markdown so difficult. Did we succeed?</p>
+                <p>If a CommonMark implementation does not already exist in your preferred environment or language, try <strong>implementing your own CommonMark parser</strong>. One of our major goals is to <a href="https://spec.commonmark.org/">strongly specify Markdown</a>, and to eliminate the many old inconsistencies and ambiguities that made using Markdown so difficult. Did we succeed?</p>
 
                 <h2>
                     <a id="where" class="anchor" href="#where"></a>Where can I find it?
                 </h2>
 
                 <h3>
-                    <a href="http://spec.commonmark.org/">spec.commonmark.org</a>
+                    <a href="https://spec.commonmark.org/">spec.commonmark.org</a>
                 </h3>
                 <p>
                     The CommonMark specification.
@@ -107,19 +107,19 @@
                     Reference implementation and validation test suite on GitHub.
                 </p>
                 <h3>
-                    <a href="http://talk.commonmark.org/">talk.commonmark.org</a>
+                    <a href="https://talk.commonmark.org/">talk.commonmark.org</a>
                 </h3>
                 <p>
-                    Public discussion area and mailing list via <a href="http://www.discourse.org">Discourse</a>.
+                    Public discussion area and mailing list via <a href="https://www.discourse.org">Discourse</a>.
                 </p>
                 <h3>
-                    <a href="http://commonmark.org/help">commonmark.org/help</a>
+                    <a href="https://commonmark.org/help">commonmark.org/help</a>
                 </h3>
                 <p>
                     Quick reference card and interactive tutorial for learning Markdown.
                 </p>
                 <h3>
-                    <a href="http://try.commonmark.org/">try.commonmark.org</a>
+                    <a href="https://spec.commonmark.org/dingus/">spec.commonmark.org/dingus/</a>
                 </h3>
                 <p>
                     Live testing tool powered by the reference implementation.

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -1,4 +1,4 @@
-/* http://meyerweb.com/eric/tools/css/reset/ 
+/* https://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
    License: none (public domain)
 */


### PR DESCRIPTION
**DO NOT MERGE UNTIL #16 IS COMPLETE**
*The apex domain's ([commonmark.org](http://commonmark.org/)) URLs are not available over HTTPS until that issue is resolved.*

All the modified URLs were checked to see if they are available over HTTPS by opening a new tab in the browser, entering the URL in the address bar, changing `http://` to `https://` and then verifying if the resource displayed is the same over HTTP and HTTPS for each URL, however, a few URLs automatically upgraded HTTP requests to HTTPS requests.

- [code.commonmark.org](http://code.commonmark.org/) eventually redirects to the [GitHub repo](https://spec.commonmark.org/dingus/), but this doesn't work when the domain is prefixed by `https://`, so URLs for it were not rewritten. Perhaps all references to it in CommonMark documents could be replaced by the GitHub repo link (https://github.com/commonmark/CommonMark) in a revision of this commit then?
- [try.commonmark.org](http://try.commonmark.org/) does not work over HTTPS and eventually redirects to https://spec.commonmark.org/dingus/, so I replaced all references to it with that link to the dingus. Is that fine?
- The Nanobar project's URL (http://nanobar.micronube.com/) redirects to http://nanobar.jacoborus.codes/ now, which is available over HTTPS, so I replaced it with the HTTPS version of the new URL.