### PR TITLE
Ajust "Horizontal rule" example in help page

### DIFF
--- a/help/index.html
+++ b/help/index.html
@@ -155,17 +155,17 @@
                     </tr>
                     <tr>
                         <td class="preformatted">
-                            Horizontal Rule<br/>
+                            Horizontal rule:<br/>
                             <br/>
                             ---
                         </td>
                         <td class="preformatted second-example">
-                            Horizontal Rule<br/>
+                            Horizontal rule:<br/>
                             <br/>
                             ***
                         </td>
                         <td>
-                            Horizontal Rule
+                            Horizontal rule:
                             <hr class="custom-hr" />
                         </td>
                     </tr>


### PR DESCRIPTION
- Add colon after the text, because the actual rule is underneath it.
- Lowercase "Rule", since this is a label, not a heading.

(This is a re-submission of #7)