### PR TITLE
Improve phrasing of Plum exercise instructions

### DIFF
--- a/help/tutorial/03-paragraphs.html
+++ b/help/tutorial/03-paragraphs.html
@@ -142,7 +142,7 @@
 			<div class="container">
 			  <div class="row exercise-instructions">
 				<div class="twelve columns">
-					<p>Format this poem so the lines end exactly as shown in the preview:</p>
+					<p>Format this poem so the preview shows the four lines ending exactly as shown, not running together:</p>
 				</div>
 			  </div>
 			  <div class="row">


### PR DESCRIPTION
The existing instructions are ambiguous about whether you should change the text so it matches the initial preview (i.e. all on one line), or change it so the four lines that are present in the code are also present in the preview. Hopefully this phrasing is clearer.

I just helped someone thru the tutorial, and they ran straight into this ambiguity, so it is a real source of confusion.