### PR TITLE
mention "syntax reference" on the tutorial

### DIFF
--- a/help/tutorial/index.html
+++ b/help/tutorial/index.html
@@ -57,7 +57,7 @@
                             <a href="02-emphasis.html" class="button button-primary button-next-lesson noselect">Begin Lesson</a>
                         </p>
                         <p>
-                            <a href="../" class="button button-primary button-previous noselect">What is Markdown?</a>
+                            <a href="../" class="button button-primary button-previous noselect">What is Markdown? (with basic CommonMark syntax reference)</a>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Most projects link their syntax reference help links to this tutorial.

While this is wrong of the other projects, this is an "upstream fix" for #72, which covers the case of people familiar with markdown. Even if that project sends that person to the tutorial, it is easy to glance that there is a link to the reference (and not even more basic markdown introduction as the text "what is markdown?" currently conveys)
